### PR TITLE
Review

### DIFF
--- a/dq/assess.py
+++ b/dq/assess.py
@@ -89,6 +89,7 @@ class RDFDataQualityAssessment:
         self.assess_datum_validation()
 
     def assess_date_completeness(self):
+        # TODO confirm if this is covered in existing DIP validation, if not can be implemented as SPARQL query
         assessment_name = "date_completeness"
 
         namespace, assess_namespace, result_counts, total_assessments = self.vocab_manager.init_assessment(
@@ -112,7 +113,9 @@ class RDFDataQualityAssessment:
         self.add_to_report('Assess Date Completeness', total_assessments, result_counts)
         return assessment_name, total_assessments, result_counts
 
+    # This can be implemented in SPARQL
     def assess_date_recency(self):
+
         assessment_name = "date_recency"
 
         namespace, assess_namespace, result_counts, total_assessments = self.vocab_manager.init_assessment(
@@ -142,6 +145,7 @@ class RDFDataQualityAssessment:
         self.add_to_report('Assess Date Recency', total_assessments, result_counts)
         return assessment_name, total_assessments, result_counts
 
+    # This can be implemented in SPARQL
     def assess_date_recency_old(self):
         assessment_name = "date_recency"
 
@@ -166,6 +170,7 @@ class RDFDataQualityAssessment:
         self.add_to_report('Assess Date Recency', total_assessments, result_counts)
         return assessment_name, total_assessments, result_counts
 
+    # Not sure this is necessary; RDF triplestores deduplicate data
     def assess_duplicate(self, predicates):
         """
         Assess duplicate value combinations across all subjects based on specified predicates.
@@ -212,6 +217,7 @@ class RDFDataQualityAssessment:
         self.add_to_report('Assess Duplicate Value ', total_assessments, result_counts)
         return assessment_name, total_assessments, result_counts
 
+    # This can be implemented in SPARQL
     def assess_geo_spatial_accuracy_precision(self):
         """
         Assess geo:hasMetricSpatialAccuracy precision based on coordinateUncertaintyInMeters.
@@ -245,6 +251,7 @@ class RDFDataQualityAssessment:
         self.add_to_report('Assess Geo Spatial Accuracy Precision', total_assessments, result_counts)
         return assessment_name, total_assessments, result_counts
 
+    # This can be implemented in SPARQL
     def assess_datum_completeness(self):
         assessment_name = "datum_completeness"
 
@@ -270,6 +277,7 @@ class RDFDataQualityAssessment:
         self.add_to_report('Assess Datum Completeness', total_assessments, result_counts)
         return assessment_name, total_assessments, result_counts
 
+    # Keep in Python
     def assess_datum_validation(self):
         assessment_name = "datum_validation"
 
@@ -295,6 +303,7 @@ class RDFDataQualityAssessment:
         self.add_to_report('Assess Datum Validation', total_assessments, result_counts)
         return assessment_name, total_assessments, result_counts
 
+    # Keep in Python
     def assess_datum_type(self):
         assessment_name = "datum_type"
 
@@ -321,6 +330,7 @@ class RDFDataQualityAssessment:
         self.add_to_report('Assess Datum Type', total_assessments, result_counts)
         return assessment_name, total_assessments, result_counts
 
+    # This can be implemented in SPARQL
     def has_relevant_comment(self, s, rel_comment):
         found_relevant_comment = False
         for _, _, comment in self.g.triples((s, RDFS.comment, None)):
@@ -329,6 +339,7 @@ class RDFDataQualityAssessment:
                 break
         return found_relevant_comment
 
+    # Keep in Python
     def assess_coordinate_precision(self):
         assessment_name = "coordinate_precision"
 
@@ -355,6 +366,8 @@ class RDFDataQualityAssessment:
         self.add_to_report('Assess Coordinate Precision', total_assessments, result_counts)
         return assessment_name, total_assessments, result_counts
 
+    # This can be implemented in SPARQL
+    # Can we assume that the geometry is always a point?
     def assess_coordinate_completeness(self):
         assessment_name = "coordinate_completeness"
 
@@ -385,6 +398,10 @@ class RDFDataQualityAssessment:
         self.add_to_report(f'Assess Coordinate Completeness', total_assessments, result_counts)
         return assessment_name, total_assessments, result_counts
 
+    # Keep in Python
+    # Input can be from SPARQL
+    # Might be worth confirming the distribution of dates in submissions, this could produce a large number of
+    # outliers which represent good data
     def assess_date_outlier_irq(self):
         assessment_name = "date_outlier_irq"
         namespace, assess_namespace, result_counts, total_assessments = self.vocab_manager.init_assessment(
@@ -444,6 +461,9 @@ class RDFDataQualityAssessment:
         self.add_to_report(f'Assess Date Outlier IRQ', total_assessments, result_counts)
         return assessment_name, total_assessments, result_counts
 
+    # Keep in Python
+    # Might be worth checking the output with as close to real data if we haven't already, to see if the data is
+    # clustered, and if so, are data points outside the clusters (outliers) good data.
     def assess_date_outlier_kmeans(self):
         assessment_name = "date_outlier_kmeans"
         namespace, assess_namespace, result_counts, total_assessments = self.vocab_manager.init_assessment(
@@ -525,6 +545,7 @@ class RDFDataQualityAssessment:
             self.add_to_report(f'Assess Date Outlier Kmeans', total_assessments, result_counts)
             return assessment_name, total_assessments, result_counts
 
+    # This can be implemented in SPARQL
     def assess_coordinate_in_australia_state(self):
         assessment_name = "coordinate_in_australia_state"
 
@@ -553,6 +574,7 @@ class RDFDataQualityAssessment:
         self.add_to_report(f'Assess Coordinate in Australia State', total_assessments, result_counts)
         return assessment_name, total_assessments, result_counts
 
+    # Minor FYI there is an RDFLib function for this: g.namespace_manager.expand_curie(curie)
     def __prefixed_name_to_uri(self, prefixed_name):
         prefix, _, local_part = prefixed_name.partition(':')
         for ns_prefix, namespace in self.g.namespaces():
@@ -560,6 +582,8 @@ class RDFDataQualityAssessment:
                 return URIRef(namespace + local_part)
         return URIRef(prefixed_name)  # Return the original prefixed name as a URIRef if no matching prefix is found
 
+    # Minor FYI there is an RDFLib function for this: g.compute_qname(uri) (namespace must be bound in the graph's
+    # namespace manager)
     def __uri_to_prefixed_name(self, uri):
         if not isinstance(uri, URIRef):
             raise ValueError("uri must be an instance of URIRef")
@@ -572,6 +596,8 @@ class RDFDataQualityAssessment:
 
         return str(uri)
 
+    # Keep in Python
+    # Input can be from SPARQL
     def assess_date_format_validation(self):
         assessment_name = "date_format_validation"
 
@@ -595,6 +621,9 @@ class RDFDataQualityAssessment:
         self.add_to_report(f'Assess Date Format Validation', total_assessments, result_counts)
         return assessment_name, total_assessments, result_counts
 
+    # Keep in Python
+    # Input can be from SPARQL
+    # Can we assume all geometries are points
     def assess_coordinate_unusual(self):
         assessment_name = "coordinate_unusual"
 
@@ -633,6 +662,8 @@ class RDFDataQualityAssessment:
                     return 'unusual'
         return 'usual'
 
+    # Keep in Python
+    # Input can be from SPARQL
     def assess_coordinate_outlier_zscore(self):
         assessment_name = "coordinate_outlier_zscore"
         namespace, assess_namespace, result_counts, total_assessments = self.vocab_manager.init_assessment(
@@ -693,6 +724,8 @@ class RDFDataQualityAssessment:
         self.add_to_report(f'Assess Coordinate Outlier Zscore', total_assessments, result_counts)
         return assessment_name, total_assessments, result_counts
 
+    # Keep in Python
+    # Input can be from SPARQL
     def assess_coordinate_outlier_irq(self):
         assessment_name = "coordinate_outlier_irq"
 
@@ -752,6 +785,8 @@ class RDFDataQualityAssessment:
         self.add_to_report(f'Assess Coordinate Outlier IRQ', total_assessments, result_counts)
         return assessment_name, total_assessments, result_counts
 
+    # Keep in Python
+    # Input can be from SPARQL
     def assess_coordinate_outlier_isolation_forest(self):
         assessment_name = "coordinate_outlier_isolation_forest"
 
@@ -809,6 +844,8 @@ class RDFDataQualityAssessment:
         self.add_to_report(f'Assess Coordinate Outlier Isolation Forest', total_assessments, result_counts)
         return assessment_name, total_assessments, result_counts
 
+    # Keep in Python
+    # Input can be from SPARQL
     def assess_coordinate_outlier_robust_covariance(self):
         assessment_name = "coordinate_outlier_robust_covariance"
 

--- a/dq_in_dip/README.md
+++ b/dq_in_dip/README.md
@@ -1,0 +1,12 @@
+This directory gives a minimal example of:
+1. converting individual assessments to SPARQL, and
+2. converting the inputs to an assessment to SPARQL
+
+The assessments are implemented as pytest tests, and a fixture is used to serialise the results.
+
+The tests can be run with, from the repo root:
+
+`pytest dq_in_dip/ -o pythonpath=.`
+`poetry run pytest dq_in_dip/ -o pythonpath=.`
+
+etc.

--- a/dq_in_dip/conftest.py
+++ b/dq_in_dip/conftest.py
@@ -1,0 +1,72 @@
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+from pyoxigraph import Store, RdfFormat, QueryResultsFormat
+from rdflib import BNode, SOSA, URIRef, SDO, Literal, XSD, Graph, IdentifiedNode
+
+from dq import DQAF
+from dq.vocab_manager import VocabManager
+
+
+QUERY_DIR = Path(__file__).parent / "queries"
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--datafile",
+        action="store",
+        default=Path(__file__).parent.parent / "dq/input/combined_graph.ttl",
+        help="Path to the turtle file to be validated against the DQF."
+    )
+
+@pytest.fixture(scope="session")
+def store(request):
+    datafile = request.config.getoption("datafile")
+    store = Store()
+
+    file_bytes = Path(datafile).read_bytes()
+    store.load(file_bytes, RdfFormat.TURTLE)
+
+    yield store
+
+@pytest.fixture(scope="session")
+def vocab_manager():
+    return VocabManager()
+
+@pytest.fixture(scope="session")
+def get_observation_geometries(store):
+    #TODO this query will need updating for the correct graph path to Geomtries. It is currently using a direct path in
+    # order to test the functionality.
+    """Observation geometries are reused in 14 different DQF assessments"""
+    query = (QUERY_DIR/"fixture_get_obs_geoms.rq").read_text()
+    return  store.query(query).serialize(format=QueryResultsFormat.CSV).decode()
+
+
+@pytest.fixture(scope="session")
+def result_graph():
+    g = Graph()
+    yield g
+    output_file = Path(__file__).parent / "results/mvp_results.ttl"
+    output_file.parent.mkdir(parents=True, exist_ok=True)
+    g.serialize(destination=output_file, format="turtle")
+
+def add_assessment_result(
+        result_graph: Graph,
+        subject: IdentifiedNode,
+        assessment_type: URIRef,
+        value: IdentifiedNode | Literal,
+        assessment_date=None
+):
+    result_bn = BNode()
+    result_graph.add((subject, DQAF.hasDQAFResult, result_bn))
+    result_graph.add((result_bn, SOSA.observedProperty, assessment_type))
+    result_graph.add((result_bn, SDO.value, value))
+
+    if assessment_date is None:
+        assessment_date = datetime.now()
+    elif isinstance(assessment_date, datetime.date) and not isinstance(assessment_date, datetime.datetime):
+        assessment_date = datetime.datetime.combine(assessment_date, datetime.time.min)
+
+    result_graph.add((result_bn, SOSA.resultTime, Literal(assessment_date, datatype=XSD.dateTime)))
+

--- a/dq_in_dip/queries/001.rq
+++ b/dq_in_dip/queries/001.rq
@@ -1,0 +1,16 @@
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX tern: <https://w3id.org/tern/ontologies/tern/>
+PREFIX sosa: <http://www.w3.org/ns/sosa/>
+PREFIX geo: <http://www.opengis.net/ont/geosparql#>
+
+SELECT ?observation ?hasNonEmptyPoint
+WHERE {
+    ?observation rdf:type tern:Observation .
+    BIND(EXISTS {
+            ?observation sosa:hasFeatureOfInterest ?sample .
+            ?sample rdf:type tern:Sample .
+            ?sample sosa:isResultOf/geo:hasGeometry/geo:asWKT ?wkt .
+            FILTER(REGEX(STR(?wkt), "POINT\\s*\\([^\\s]+\\s+[^\\s]+\\)"))
+        } AS ?hasNonEmptyPointBool)
+    BIND(IF(?hasNonEmptyPointBool, "non_empty", "empty") AS ?hasNonEmptyPoint)
+}

--- a/dq_in_dip/queries/fixture_get_obs_geoms.rq
+++ b/dq_in_dip/queries/fixture_get_obs_geoms.rq
@@ -1,0 +1,8 @@
+PREFIX geo: <http://www.opengis.net/ont/geosparql#>
+
+SELECT ?observation ?lon ?lat
+WHERE {
+    ?observation geo:hasGeometry/geo:asWKT ?geometry_wkt .
+    BIND(REPLACE(STR(?geometry_wkt), ".*POINT \\(([^ ]+) ([^ ]+)\\).*", "$1") AS ?lon)
+    BIND(REPLACE(STR(?geometry_wkt), ".*POINT \\(([^ ]+) ([^ ]+)\\).*", "$2") AS ?lat)
+}

--- a/dq_in_dip/test_mvp.py
+++ b/dq_in_dip/test_mvp.py
@@ -1,0 +1,73 @@
+import json
+from io import StringIO
+
+import numpy as np
+import pandas as pd
+from pyoxigraph import QueryResultsFormat
+from rdflib import URIRef, Literal, XSD
+from shapely.wkt import loads
+
+from conftest import QUERY_DIR
+from dq_in_dip.conftest import add_assessment_result
+
+
+def test_001(store, vocab_manager, result_graph):
+    # TODO having now written test_002, this test_001 could actually reuse the get_observation_geometries fixture as
+    #  well, rather than needing to run a separate query. The last step of the analysis would then be outside the SPARQL
+    #  query.
+    """
+    coordinate_completeness
+    This is an example of an assessment that can be done in SPARQL.
+    """
+    assessment_name = "coordinate_completeness"
+    namespace, assess_namespace, result_counts, total_assessments = vocab_manager.init_assessment(
+        assessment_name)
+
+    query = (QUERY_DIR/"001.rq").read_text()
+    results_json = store.query(query).serialize(format=QueryResultsFormat.JSON)
+    results_dict = json.loads(results_json)
+    for result in results_dict["results"]["bindings"]:
+        observation = URIRef(result["observation"]["value"])
+        hasNonEmptyPoint = result["hasNonEmptyPoint"]["value"]
+        add_assessment_result(result_graph, observation, assess_namespace, namespace[hasNonEmptyPoint])
+
+def test_002(vocab_manager, result_graph, get_observation_geometries):
+    """
+    coordinate_outlier_irq
+    This is an example of an assessment that should be done in Python (statistical analysis), but where the inputs to
+    the analysis can come from a SPARQL query.
+    """
+    assessment_name = "coordinate_outlier_irq"
+    namespace, assess_namespace, result_counts, total_assessments = vocab_manager.init_assessment(
+        assessment_name)
+
+
+    df = pd.read_csv(StringIO(get_observation_geometries))
+    df = df[(df['lon'] != 0) | (df['lat'] != 0)]
+    df = df.dropna(subset=['lon', 'lat'])
+
+    if df.shape[0] < 4:
+        print("Insufficient data for outlier analysis.")
+        df['outlier'] = None  # No analysis possible
+        return df
+
+    # Compute IQR for latitude and longitude
+    lat_q1, lat_q3 = np.percentile(df['lat'], [25, 75])
+    long_q1, long_q3 = np.percentile(df['lon'], [25, 75])
+    lat_iqr = lat_q3 - lat_q1
+    long_iqr = long_q3 - long_q1
+
+    # Identify outliers
+    df['lat_outlier'] = (df['lat'] < lat_q1 - 1.5 * lat_iqr) | (df['lat'] > lat_q3 + 1.5 * lat_iqr)
+    df['long_outlier'] = (df['lon'] < long_q1 - 1.5 * long_iqr) | (df['lon'] > long_q3 + 1.5 * long_iqr)
+    df['outlier'] = df['lat_outlier'] | df['long_outlier']
+
+    outlier_label_map = {
+        True: "outlier_coordinate",
+        False: "normal_coordinate"
+    }
+
+    for result in df.iterrows():
+        observation = URIRef(result[1]['observation'])
+        outlier = outlier_label_map[result[1]['outlier']]
+        add_assessment_result(result_graph, observation, assess_namespace, namespace[outlier])


### PR DESCRIPTION
_Using a draft PR as a review mechanism - not intended to be merged._

**Code review comments**
Convert RDFLib to SPARQL where possible. I have repeated the following comments in “assessy.py”:

- \# This can be implemented in SPARQL”
Some of the checks that can be implemented in SPARQL might be covered in the DIP, i.e. if data is ABIS valid, it must meet some of these checks already. To check with Ashley which specific ones.

- \# Input can be from SPARQL
The check still makes sense to do in Python, but the inputs of it can be from a SPARQL query. We would expect SPARQL against Oxigraph to be more performant than RDFLib. If at a later point data from the BDR can be used in the DQF assessment, the same SPARQL queries can be used to query the BDR.

- \# Keep in Python
Too hard or unwise to implement in SPARQL e.g. KMeans etc.

**Size of output**
Assuming the Final_Usecase_Results.ttl is the RDF merge of the input file for validation (TBC, looks like it includes the original data) and the DQF results, as an example we have:
- Input file size: dq/input/combined_graph.ttl: 13.6 MB
- Output file size: result/Final_Usecase_Results.ttl: 25.8 MB
- Diff, i.e. assumed size of DQF only results: 12.2 MB  

This would necessitate an almost doubling of the size of the BDR to store all DQF results.
Some thoughts:
Can the output size be reduced through modelling changes
- For example, can a model be used where only errors are recorded? For example an entire record or dataset is marked as being consistent with the DQF, with only the detail of exceptions to this being recorded.
- For qualitative measures that are not binary, can a micro format be used (where the definition/interpretation can still be modelled in RDF)

**General considerations**
What is the impact of not being able to include data from the BDR in the DQF (i.e. the only data available for analysis is the individual submission(s))?
- Some of the statistical measures should be analysed in the context of the BDR data, so this analysis can not be done.
- NB for some tasks, not including the BDR data would be most appropriate.

If data does need to be extracted from the BDR (pending a technical design), how should this be done?
- Once the inputs to the statistical measures are converted to SPARQL queries (e.g. for a list of points for the geographic outliers), the same SPARQL queries can be executed in the Production BDR. This will produce the “minimum” data needed to be extracted from the BDR, and ensure it’s in the same format for the statistical analysis. This is likely tabular format.
- As the BDR will be on a much larger set of data, there could be performance issues if the RDF is taken as a subgraph and loaded into RDFLib in memory.

**Other thoughts**
Are statistical measures a good indicator of erroneous data?
As an example, if the data is normally distributed (may not be a good assumption), for the IQR, about 0.7% of data will be statistical outliers, or seven records per thousand. Presumably these records are flagged, and a human reviewer then reviews them. How does a reviewer then determine that the records are in fact erroneous?

Ideally there is a reference set of data that has been confirmed to be erroneous (for example by suppliers telling us what they typically remove; looking at their deletion requests; human analysis of the data etc.). From this we can look for statistical “signatures” for erroneous data. It may be hard to collate a reference set of erroneous records.
